### PR TITLE
add alert dialog missing style

### DIFF
--- a/rave_android/src/main/java/com/flutterwave/raveandroid/account/AccountFragment.java
+++ b/rave_android/src/main/java/com/flutterwave/raveandroid/account/AccountFragment.java
@@ -211,7 +211,7 @@ public class AccountFragment extends Fragment implements AccountUiContract.View,
     public void showGTBankAmountIssue() {
 
         if (getActivity() != null) {
-            AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+            AlertDialog.Builder builder = new AlertDialog.Builder(getActivity(), R.style.RaveDialogStyle);
             builder.setMessage(getResources().getString(R.string.payWithBankAmountLimitPrompt));
             builder.setPositiveButton(getResources().getString(R.string.ok), new DialogInterface.OnClickListener() {
                 @Override

--- a/rave_android/src/main/java/com/flutterwave/raveandroid/banktransfer/BankTransferFragment.java
+++ b/rave_android/src/main/java/com/flutterwave/raveandroid/banktransfer/BankTransferFragment.java
@@ -322,7 +322,7 @@ public class BankTransferFragment extends Fragment implements BankTransferUiCont
 
     @Override
     public void onTransactionFeeFetched(String charge_amount, final Payload payload, String fee) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity(), R.style.RaveDialogStyle);
         builder.setMessage("You will be charged a total of " + charge_amount + ravePayInitializer.getCurrency() + ". Do you want to continue?");
         builder.setPositiveButton("YES", new DialogInterface.OnClickListener() {
             @Override

--- a/rave_android/src/main/java/com/flutterwave/raveandroid/ussd/UssdFragment.java
+++ b/rave_android/src/main/java/com/flutterwave/raveandroid/ussd/UssdFragment.java
@@ -295,7 +295,7 @@ public class UssdFragment extends Fragment implements UssdUiContract.View, View.
 
     @Override
     public void onTransactionFeeFetched(String charge_amount, final Payload payload, String fee) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity(), R.style.RaveDialogStyle);
         builder.setMessage("You will be charged a total of " + charge_amount + " " + ravePayInitializer.getCurrency() + ". Do you want to continue?");
         builder.setPositiveButton("YES", new DialogInterface.OnClickListener() {
             @Override


### PR DESCRIPTION
Alert dialogs in **pay with ussd**, **pay with bank transfer** and **SA Bank Transfer** don't have style applied hence causing the dialog button text to be invisible. 

This fix adds style to the different payment method alert dialog