### PR TITLE
Bugfix/fix exception crash

### DIFF
--- a/rave_android/src/main/java/com/flutterwave/raveandroid/account/AccountFragment.java
+++ b/rave_android/src/main/java/com/flutterwave/raveandroid/account/AccountFragment.java
@@ -401,8 +401,10 @@ public class AccountFragment extends Fragment implements AccountUiContract.View,
     public void collectOtp(String publicKey, String flutterwaveReference, String validateInstruction) {
         this.flwRef = flutterwaveReference;
 
-        new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
-                .showOtpScreen(validateInstruction);
+        if (isAdded()){
+            new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
+                    .showOtpScreen(validateInstruction);
+        }
     }
 
     @Override
@@ -424,8 +426,10 @@ public class AccountFragment extends Fragment implements AccountUiContract.View,
     @Override
     public void displayInternetBankingPage(String authurl, String flwRef) {
         this.flwRef = flwRef;
-        new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
+        if(isAdded()){
+            new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
                 .showWebpageVerificationScreen(authurl);
+        }
     }
 
     @Override

--- a/rave_android/src/main/java/com/flutterwave/raveandroid/ach/AchFragment.java
+++ b/rave_android/src/main/java/com/flutterwave/raveandroid/ach/AchFragment.java
@@ -157,9 +157,10 @@ public class AchFragment extends Fragment implements AchUiContract.View, View.On
 
     @Override
     public void showWebView(String authUrl, String flwRef) {
-
-        new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
-                .showWebpageVerificationScreen(authUrl);
+        if (isAdded()){
+            new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
+                    .showWebpageVerificationScreen(authUrl);
+        }
     }
 
     private void dismissDialog() {

--- a/rave_android/src/main/java/com/flutterwave/raveandroid/barter/BarterFragment.java
+++ b/rave_android/src/main/java/com/flutterwave/raveandroid/barter/BarterFragment.java
@@ -169,8 +169,10 @@ public class BarterFragment extends Fragment implements BarterUiContract.View {
     public void loadBarterCheckout(String authUrlCrude, String flwRef) {
 
         this.flwRef = flwRef;
-        new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
-                .showBarterCheckoutScreen(authUrlCrude, flwRef);
+        if(isAdded()){
+            new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
+                    .showBarterCheckoutScreen(authUrlCrude, flwRef);
+        }
 
     }
 

--- a/rave_android/src/main/java/com/flutterwave/raveandroid/card/CardFragment.java
+++ b/rave_android/src/main/java/com/flutterwave/raveandroid/card/CardFragment.java
@@ -485,7 +485,9 @@ public class CardFragment extends Fragment implements View.OnClickListener, Card
      * @param message = text to display
      */
     public void showToast(String message) {
-        Toast.makeText(requireContext(), message+"", Toast.LENGTH_SHORT).show();
+        if(isAdded()){
+            Toast.makeText(requireContext(), message+"", Toast.LENGTH_SHORT).show();
+        }
     }
 
     /**

--- a/rave_android/src/main/java/com/flutterwave/raveandroid/card/CardFragment.java
+++ b/rave_android/src/main/java/com/flutterwave/raveandroid/card/CardFragment.java
@@ -421,8 +421,10 @@ public class CardFragment extends Fragment implements View.OnClickListener, Card
     @Override
     public void collectCardPin(final Payload payload) {
         this.payLoad = payload;   //added so as to get back in onActivityResult
-        new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
-                .showPinScreen();
+        if (isAdded()){
+            new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
+                    .showPinScreen();
+        }
     }
 
     @Override
@@ -510,15 +512,19 @@ public class CardFragment extends Fragment implements View.OnClickListener, Card
     public void collectOtp(String flwRef, String message) {
         this.flwRef = flwRef;
         dismissDialog();
-        new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
-                .showOtpScreen(message);
+        if(isAdded()){
+            new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
+                    .showOtpScreen(message);
+        }
     }
 
     public void showOTPLayoutForSavedCard(Payload payload, String authInstruction) {
         this.payLoad = payload;
         dismissDialog();
-        new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
-                .showOtpScreenForSavedCard(authInstruction);
+        if(isAdded()){
+            new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
+                    .showOtpScreenForSavedCard(authInstruction);
+        }
     }
 
     @Override
@@ -578,8 +584,10 @@ public class CardFragment extends Fragment implements View.OnClickListener, Card
     public void showWebPage(String authenticationUrl, String flwRef) {
 
         this.flwRef = flwRef;
-        new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
-                .showWebpageVerificationScreen(authenticationUrl);
+        if(isAdded()){
+            new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
+                    .showWebpageVerificationScreen(authenticationUrl);
+        }
     }
 
     @Override
@@ -776,8 +784,10 @@ public class CardFragment extends Fragment implements View.OnClickListener, Card
     public void collectCardAddressDetails(final Payload payload, String authModel) {
         this.payLoad = payload;
         this.authModel = authModel;
-        new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
-                .showAddressScreen();
+        if(isAdded()){
+            new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
+                    .showAddressScreen();
+        }
     }
 
     private class ExpiryWatcher implements TextWatcher {

--- a/rave_android/src/main/java/com/flutterwave/raveandroid/card/CardFragment.java
+++ b/rave_android/src/main/java/com/flutterwave/raveandroid/card/CardFragment.java
@@ -782,13 +782,9 @@ public class CardFragment extends Fragment implements View.OnClickListener, Card
 
     private class ExpiryWatcher implements TextWatcher {
 
-        private final Calendar calendar;
-        private final SimpleDateFormat simpleDateFormat;
         private String lastInput = "";
 
         public ExpiryWatcher() {
-            calendar = Calendar.getInstance();
-            simpleDateFormat = new SimpleDateFormat("MM/yy");
         }
 
         @Override
@@ -805,44 +801,47 @@ public class CardFragment extends Fragment implements View.OnClickListener, Card
         public void afterTextChanged(Editable editable) {
             String input = editable.toString();
             String cardExpiryToSet = cardExpiryTv.getText().toString() + "/";
+            String defaultExpiry = "12";
 
-            try {
-                calendar.setTime(simpleDateFormat.parse(input));
-            } catch (ParseException e) {
+            if (editable.length() == 2 && !lastInput.endsWith("/")) {
 
-                if (editable.length() == 2 && !lastInput.endsWith("/")) {
-
+                try {
                     int month = Integer.parseInt(input);
                     if (month <= 12) {
                         cardExpiryTv.setText(cardExpiryToSet);
                         cardExpiryTv.setSelection(cardExpiryTv.getText().toString().length());
                     } else {
-                        cardExpiryTv.setText(getResources().getString(R.string.defaultCardExpiry));
+                        cardExpiryTv.setText(defaultExpiry);
                         cardExpiryTv.setSelection(cardExpiryTv.getText().toString().length());
                     }
-                } else if (editable.length() == 2 && lastInput.endsWith("/")) {
-                    try {
-                        int month = Integer.parseInt(input);
-                        if (month <= 12) {
-                            cardExpiryTv.setText(cardExpiryTv.getText().toString().substring(0, 1));
-                            cardExpiryTv.setSelection(cardExpiryTv.getText().toString().length());
-                        } else {
-                            cardExpiryTv.setText(getResources().getString(R.string.defaultCardExpiry));
-                            cardExpiryTv.setSelection(cardExpiryTv.getText().toString().length());
-                        }
-                    } catch (NumberFormatException ex) {
-                        cardExpiryTv.setText(input.replace("/", ""));
+                }catch (NumberFormatException ex){
+                    cardExpiryTv.setText(defaultExpiry);
+                    cardExpiryTv.setSelection(cardExpiryTv.getText().toString().length());
+                }
+            } else if (editable.length() == 2 && lastInput.endsWith("/")) {
+                try {
+                    int month = Integer.parseInt(input);
+                    if (month <= 12) {
+                        cardExpiryTv.setText(cardExpiryTv.getText().toString().substring(0, 1));
                         cardExpiryTv.setSelection(cardExpiryTv.getText().toString().length());
-                    } catch (Resources.NotFoundException ex) {
-                        ex.printStackTrace();
+                    } else {
+                        cardExpiryTv.setText(defaultExpiry);
+                        cardExpiryTv.setSelection(cardExpiryTv.getText().toString().length());
                     }
+                } catch (NumberFormatException ex) {
+                    cardExpiryTv.setText(input.replace("/", ""));
+                    cardExpiryTv.setSelection(cardExpiryTv.getText().toString().length());
+                }
 
-                } else if (editable.length() == 1) {
+            } else if (editable.length() == 1) {
+                try {
                     int month = Integer.parseInt(input);
                     if (month > 1) {
-                        cardExpiryTv.setText("0" + cardExpiryTv.getText().toString() + "/");
+                        cardExpiryTv.setText(String.format(getString(R.string.formatted_expiry), input));
                         cardExpiryTv.setSelection(cardExpiryTv.getText().toString().length());
                     }
+                }catch (NumberFormatException ignored){
+
                 }
             }
 

--- a/rave_android/src/main/java/com/flutterwave/raveandroid/francMobileMoney/FrancMobileMoneyFragment.java
+++ b/rave_android/src/main/java/com/flutterwave/raveandroid/francMobileMoney/FrancMobileMoneyFragment.java
@@ -203,8 +203,10 @@ public class FrancMobileMoneyFragment extends Fragment implements FrancMobileMon
     public void showWebPage(String authenticationUrl, String flwRef) {
 
         this.flwRef = flwRef;
-        new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
-                .showWebpageVerificationScreen(authenticationUrl,flwRef);
+        if (isAdded()){
+            new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
+                    .showWebpageVerificationScreen(authenticationUrl,flwRef);
+        }
     }
 
 

--- a/rave_android/src/main/java/com/flutterwave/raveandroid/ghmobilemoney/GhMobileMoneyFragment.java
+++ b/rave_android/src/main/java/com/flutterwave/raveandroid/ghmobilemoney/GhMobileMoneyFragment.java
@@ -232,8 +232,10 @@ public class GhMobileMoneyFragment extends Fragment implements GhMobileMoneyUiCo
     ) {
 
 //        this.flwRef = flwRef;
-        new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
-                .showWebpageVerificationScreen(authenticationUrl);
+        if(isAdded()){
+            new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
+                    .showWebpageVerificationScreen(authenticationUrl);
+        }
     }
 
 

--- a/rave_android/src/main/java/com/flutterwave/raveandroid/rwfmobilemoney/RwfMobileMoneyFragment.java
+++ b/rave_android/src/main/java/com/flutterwave/raveandroid/rwfmobilemoney/RwfMobileMoneyFragment.java
@@ -219,8 +219,10 @@ public class RwfMobileMoneyFragment extends Fragment implements RwfMobileMoneyUi
 
     @Override
     public void showWebPage(String authenticationUrl) {
-        new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
-                .showWebpageVerificationScreen(authenticationUrl);
+        if (isAdded()){
+            new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
+                    .showWebpageVerificationScreen(authenticationUrl);
+        }
     }
 
     @Override

--- a/rave_android/src/main/java/com/flutterwave/raveandroid/sabankaccount/SaBankAccountFragment.java
+++ b/rave_android/src/main/java/com/flutterwave/raveandroid/sabankaccount/SaBankAccountFragment.java
@@ -137,8 +137,10 @@ public class SaBankAccountFragment extends Fragment implements SaBankAccountUiCo
     @Override
     public void showWebView(String authUrl, String flwRef){
         this.flwRef = flwRef;
-        new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
-                .showWebpageVerificationScreen(authUrl);
+        if (isAdded()){
+            new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
+                    .showWebpageVerificationScreen(authUrl);
+        }
     }
 
     @Override

--- a/rave_android/src/main/java/com/flutterwave/raveandroid/ugmobilemoney/UgMobileMoneyFragment.java
+++ b/rave_android/src/main/java/com/flutterwave/raveandroid/ugmobilemoney/UgMobileMoneyFragment.java
@@ -234,8 +234,10 @@ public class UgMobileMoneyFragment extends Fragment implements UgMobileMoneyUiCo
 
     @Override
     public void showWebPage(String authenticationUrl) {
-        new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
-                .showWebpageVerificationScreen(authenticationUrl);
+        if(isAdded()){
+            new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
+                    .showWebpageVerificationScreen(authenticationUrl);
+        }
     }
 
     @Override

--- a/rave_android/src/main/java/com/flutterwave/raveandroid/zmmobilemoney/ZmMobileMoneyFragment.java
+++ b/rave_android/src/main/java/com/flutterwave/raveandroid/zmmobilemoney/ZmMobileMoneyFragment.java
@@ -267,8 +267,10 @@ public class ZmMobileMoneyFragment extends Fragment implements ZmMobileMoneyUiCo
 
     @Override
     public void showWebPage(String authenticationUrl) {
-        new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
-                .showWebpageVerificationScreen(authenticationUrl);
+        if(isAdded()){
+            new RaveVerificationUtils(this, ravePayInitializer.isStaging(), ravePayInitializer.getPublicKey(), ravePayInitializer.getTheme())
+                    .showWebpageVerificationScreen(authenticationUrl);
+        }
     }
 
     @Override

--- a/rave_android/src/main/res/values/strings.xml
+++ b/rave_android/src/main/res/values/strings.xml
@@ -203,5 +203,6 @@
     <string name="please_select_a_card">Please select a card</string>
     <string name="barter_funding">Barter Funding</string>
     <string name="verifying_transaction">Verifying transaction...</string>
+    <string name="formatted_expiry">0%1$s/</string>
 
 </resources>


### PR DESCRIPTION
This Pr resolves the following exception crashes.

- NumberForException: handle exception in Card Fragment when inputing card expiry details
- NullPointerException: Check if Card Fragment is added to HostActivity before navigating to next screen
- IllegalStateException: Check if Card Fragment is added to HostActivity before displaying toast message using requireContext()